### PR TITLE
Add SQLite-based cache for BioPortal search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ To use with Claude Desktop app:
       ],
       "env": {
         "CEDAR_API_KEY": "your-cedar-key",
-        "BIOPORTAL_API_KEY": "your-bioportal-key"
+        "BIOPORTAL_API_KEY": "your-bioportal-key",
+        "CEDAR_MCP_CACHE_TTL_SECONDS": "86400",
+        "CEDAR_MCP_CACHE_DIR": "/path/to/custom/location"
       }
     }
   }
@@ -106,13 +108,17 @@ Or if you have it installed locally:
     "cedar-mcp": {
       "command": "cedar-mcp",
       "env": {
-        "CEDAR_API_KEY": "your-cedar-key", 
-        "BIOPORTAL_API_KEY": "your-bioportal-key"
+        "CEDAR_API_KEY": "your-cedar-key",
+        "BIOPORTAL_API_KEY": "your-bioportal-key",
+        "CEDAR_MCP_CACHE_TTL_SECONDS": "86400",
+        "CEDAR_MCP_CACHE_DIR": "/path/to/custom/location"
       }
     }
   }
 }
 ```
+
+The `CEDAR_MCP_CACHE_TTL_SECONDS` and `CEDAR_MCP_CACHE_DIR` environment variables are optional. When set under the `"env"` key, Claude Desktop injects them into the server process environment before it starts, so the cache picks them up automatically. If omitted, the defaults apply (24-hour TTL and a platform-specific cache directory — see [Cache Configuration](#cache-configuration)).
 
 ## Available Tools
 
@@ -123,6 +129,22 @@ Here is the list of CEDAR tools with a short description
 * `term_search_from_branch`: Searches BioPortal for standardized ontology terms within a specific branch.
 * `term_search_from_ontology`: Searches BioPortal for standardized ontology terms within an entire ontology.
 * `get_branch_children`: Fetches all immediate children terms for a given branch in an ontology.
+* `remove_stale_cache_entries`: Removes expired entries from the BioPortal search cache.
+* `clear_bioportal_cache`: Clears all entries from the BioPortal search cache.
+
+## Cache Configuration
+
+BioPortal search results are cached locally using SQLite to reduce latency and API load. The cache persists across server restarts.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CEDAR_MCP_CACHE_TTL_SECONDS` | `86400` (24 hours) | Time-to-live for cached BioPortal responses |
+| `CEDAR_MCP_CACHE_DIR` | Platform-specific (see below) | Override the cache directory location |
+
+**Default cache locations:**
+- **macOS:** `~/Library/Caches/cedar-mcp`
+- **Linux:** `$XDG_CACHE_HOME/cedar-mcp` or `~/.cache/cedar-mcp`
+- **Windows:** `%LOCALAPPDATA%/cedar-mcp/cache`
 
 ## Development
 

--- a/src/cedar_mcp/cache.py
+++ b/src/cedar_mcp/cache.py
@@ -1,0 +1,243 @@
+"""
+BioPortal search cache with TTL using SQLite backend.
+
+Provides persistent caching for BioPortal API responses to reduce latency
+and API load during metadata authoring sessions. Cache entries expire
+based on a configurable TTL (default: 24 hours).
+"""
+
+import hashlib
+import json
+import os
+import platform
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Default TTL: 24 hours
+DEFAULT_TTL_SECONDS = 86400
+
+
+def _get_cache_dir() -> Path:
+    """
+    Get the platform-appropriate cache directory for cedar-mcp.
+
+    Uses the ``CEDAR_MCP_CACHE_DIR`` environment variable if set,
+    otherwise falls back to a platform-specific default.
+
+    Returns:
+        Path to the cache directory.
+    """
+    env_override = os.environ.get("CEDAR_MCP_CACHE_DIR")
+    if env_override:
+        return Path(env_override)
+
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / "Library" / "Caches" / "cedar-mcp"
+    elif system == "Windows":
+        local_app_data = os.environ.get("LOCALAPPDATA", "")
+        if local_app_data:
+            return Path(local_app_data) / "cedar-mcp" / "cache"
+        return Path.home() / "AppData" / "Local" / "cedar-mcp" / "cache"
+    else:
+        # Linux and other POSIX systems
+        xdg_cache = os.environ.get("XDG_CACHE_HOME", "")
+        if xdg_cache:
+            return Path(xdg_cache) / "cedar-mcp"
+        return Path.home() / ".cache" / "cedar-mcp"
+
+
+def _get_ttl() -> int:
+    """
+    Get the TTL for cache entries in seconds.
+
+    Reads from the ``CEDAR_MCP_CACHE_TTL_SECONDS`` environment variable,
+    falling back to 86400 (24 hours).
+
+    Returns:
+        TTL in seconds.
+    """
+    env_val = os.environ.get("CEDAR_MCP_CACHE_TTL_SECONDS")
+    if env_val is not None:
+        try:
+            return int(env_val)
+        except ValueError:
+            return DEFAULT_TTL_SECONDS
+    return DEFAULT_TTL_SECONDS
+
+
+def _make_cache_key(func_name: str, **params: Any) -> str:
+    """
+    Create a deterministic cache key from function name and parameters.
+
+    Parameters are sorted by key to ensure identical calls produce the same
+    hash regardless of argument order. The API key is excluded from the hash.
+
+    Args:
+        func_name: Name of the cached function.
+        **params: Function parameters (excluding API keys).
+
+    Returns:
+        SHA-256 hex digest string.
+    """
+    key_data = {"func_name": func_name, "params": dict(sorted(params.items()))}
+    key_json = json.dumps(key_data, sort_keys=True, ensure_ascii=True)
+    return hashlib.sha256(key_json.encode("utf-8")).hexdigest()
+
+
+class BioPortalCache:
+    """
+    SQLite-backed cache for BioPortal API responses.
+
+    Attributes:
+        db_path: Path to the SQLite database file.
+        ttl_seconds: Time-to-live for cache entries in seconds.
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        ttl_seconds: Optional[int] = None,
+    ) -> None:
+        """
+        Initialize the cache, creating the database and table if needed.
+
+        Args:
+            db_path: Path to the SQLite database file. Defaults to a
+                     platform-appropriate location.
+            ttl_seconds: TTL for cache entries. Defaults to the value from
+                        ``CEDAR_MCP_CACHE_TTL_SECONDS`` or 86400.
+        """
+        if db_path is None:
+            cache_dir = _get_cache_dir()
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            db_path = cache_dir / "bioportal_cache.db"
+        else:
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.db_path = db_path
+        self.ttl_seconds = ttl_seconds if ttl_seconds is not None else _get_ttl()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Create the cache table if it does not exist."""
+        with sqlite3.connect(str(self.db_path)) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    func_name TEXT NOT NULL,
+                    params_summary TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    ttl_seconds INTEGER NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def get(self, func_name: str, **params: Any) -> Optional[Dict[str, Any]]:
+        """
+        Retrieve a cached result if it exists and has not expired.
+
+        On a cache hit, the returned dictionary includes ``_cached: True``
+        and ``_cache_age_seconds`` indicating how old the entry is.
+
+        Args:
+            func_name: Name of the cached function.
+            **params: Function parameters used to build the cache key.
+
+        Returns:
+            Cached result dict with metadata on hit, or ``None`` on miss/expiry.
+        """
+        key = _make_cache_key(func_name, **params)
+        now = time.time()
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            row = conn.execute(
+                "SELECT value, created_at, ttl_seconds FROM cache WHERE key = ?",
+                (key,),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        value_json, created_at, ttl = row
+        age = now - created_at
+        if age > ttl:
+            # Entry expired — remove it
+            with sqlite3.connect(str(self.db_path)) as conn:
+                conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                conn.commit()
+            return None
+
+        result: Dict[str, Any] = json.loads(value_json)
+        result["_cached"] = True
+        result["_cache_age_seconds"] = round(age, 1)
+        return result
+
+    def set(self, func_name: str, result: Dict[str, Any], **params: Any) -> None:
+        """
+        Store a result in the cache.
+
+        Error responses (dicts containing an ``"error"`` key) are **not** cached.
+
+        Args:
+            func_name: Name of the cached function.
+            result: The API result to cache.
+            **params: Function parameters used to build the cache key.
+        """
+        if "error" in result:
+            return
+
+        key = _make_cache_key(func_name, **params)
+        value_json = json.dumps(result, ensure_ascii=True)
+        params_summary = json.dumps(
+            dict(sorted(params.items())), ensure_ascii=True, indent=2
+        )
+
+        with sqlite3.connect(str(self.db_path)) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO cache
+                    (key, value, func_name, params_summary, created_at, ttl_seconds)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (key, value_json, func_name, params_summary, time.time(), self.ttl_seconds),
+            )
+            conn.commit()
+
+    def remove_stale(self) -> Dict[str, int]:
+        """
+        Delete all expired cache entries.
+
+        Returns:
+            Dictionary with ``removed_count`` and ``remaining_count``.
+        """
+        now = time.time()
+        with sqlite3.connect(str(self.db_path)) as conn:
+            cursor = conn.execute(
+                "DELETE FROM cache WHERE (? - created_at) > ttl_seconds",
+                (now,),
+            )
+            removed = cursor.rowcount
+            conn.commit()
+            remaining = conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+
+        return {"removed_count": removed, "remaining_count": remaining}
+
+    def clear_all(self) -> Dict[str, int]:
+        """
+        Delete all cache entries.
+
+        Returns:
+            Dictionary with ``cleared_count``.
+        """
+        with sqlite3.connect(str(self.db_path)) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+            conn.execute("DELETE FROM cache")
+            conn.commit()
+
+        return {"cleared_count": count}

--- a/src/cedar_mcp/cache.py
+++ b/src/cedar_mcp/cache.py
@@ -205,7 +205,14 @@ class BioPortalCache:
                     (key, value, func_name, params_summary, created_at, ttl_seconds)
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (key, value_json, func_name, params_summary, time.time(), self.ttl_seconds),
+                (
+                    key,
+                    value_json,
+                    func_name,
+                    params_summary,
+                    time.time(),
+                    self.ttl_seconds,
+                ),
             )
             conn.commit()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 
 import os
+from pathlib import Path
+
 import pytest
 from typing import Dict, Any
 from dotenv import load_dotenv
+
+from cedar_mcp.cache import BioPortalCache
 
 # Load test environment variables
 load_dotenv(".env.test")
@@ -25,6 +29,12 @@ def bioportal_api_key() -> str:
     if not api_key:
         pytest.skip("BIOPORTAL_API_KEY not found in .env.test")
     return api_key
+
+
+@pytest.fixture
+def tmp_cache(tmp_path: Path) -> BioPortalCache:
+    """Provide a BioPortalCache backed by a temporary database."""
+    return BioPortalCache(db_path=tmp_path / "test_cache.db", ttl_seconds=3600)
 
 
 @pytest.fixture

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,141 @@
+"""Unit tests for the BioPortal search cache module."""
+
+import time
+from pathlib import Path
+
+import pytest
+
+from cedar_mcp.cache import BioPortalCache, _get_cache_dir, _make_cache_key
+
+
+@pytest.mark.unit
+class TestMakeCacheKey:
+    """Tests for the _make_cache_key helper."""
+
+    def test_returns_hex_string(self) -> None:
+        """Cache key should be a hex-encoded SHA-256 digest."""
+        key = _make_cache_key("func", a="1")
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+    def test_deterministic(self) -> None:
+        """Same inputs should always produce the same key."""
+        k1 = _make_cache_key("search", q="aspirin", onto="CHEBI")
+        k2 = _make_cache_key("search", q="aspirin", onto="CHEBI")
+        assert k1 == k2
+
+    def test_param_order_irrelevant(self) -> None:
+        """Parameter order should not affect the cache key."""
+        k1 = _make_cache_key("search", a="1", b="2")
+        k2 = _make_cache_key("search", b="2", a="1")
+        assert k1 == k2
+
+    def test_different_params_produce_different_keys(self) -> None:
+        """Different parameter values should produce different keys."""
+        k1 = _make_cache_key("search", q="aspirin")
+        k2 = _make_cache_key("search", q="glucose")
+        assert k1 != k2
+
+    def test_different_func_names_produce_different_keys(self) -> None:
+        """Different function names should produce different keys."""
+        k1 = _make_cache_key("func_a", q="aspirin")
+        k2 = _make_cache_key("func_b", q="aspirin")
+        assert k1 != k2
+
+
+@pytest.mark.unit
+class TestGetCacheDir:
+    """Tests for _get_cache_dir."""
+
+    def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """CEDAR_MCP_CACHE_DIR should override the default location."""
+        custom_dir = tmp_path / "custom_cache"
+        monkeypatch.setenv("CEDAR_MCP_CACHE_DIR", str(custom_dir))
+        assert _get_cache_dir() == custom_dir
+
+
+@pytest.mark.unit
+class TestBioPortalCache:
+    """Tests for the BioPortalCache class."""
+
+    def test_miss_returns_none(self, tmp_cache: BioPortalCache) -> None:
+        """A cache miss should return None."""
+        result = tmp_cache.get("search", q="nonexistent")
+        assert result is None
+
+    def test_set_get_roundtrip(self, tmp_cache: BioPortalCache) -> None:
+        """Stored values should be retrievable."""
+        data = {"collection": [{"prefLabel": "Aspirin"}]}
+        tmp_cache.set("search", data, q="aspirin", onto="CHEBI")
+
+        cached = tmp_cache.get("search", q="aspirin", onto="CHEBI")
+        assert cached is not None
+        assert cached["collection"] == [{"prefLabel": "Aspirin"}]
+        assert cached["_cached"] is True
+        assert "_cache_age_seconds" in cached
+
+    def test_error_responses_not_cached(self, tmp_cache: BioPortalCache) -> None:
+        """Results containing an 'error' key should not be stored."""
+        tmp_cache.set("search", {"error": "API failed"}, q="aspirin")
+        assert tmp_cache.get("search", q="aspirin") is None
+
+    def test_ttl_expiration(self, tmp_path: Path) -> None:
+        """Expired entries should return None on get."""
+        cache = BioPortalCache(db_path=tmp_path / "ttl.db", ttl_seconds=1)
+        cache.set("search", {"data": "ok"}, q="aspirin")
+
+        # Should be available immediately
+        assert cache.get("search", q="aspirin") is not None
+
+        # Wait for expiry
+        time.sleep(1.1)
+        assert cache.get("search", q="aspirin") is None
+
+    def test_remove_stale_deletes_expired(self, tmp_path: Path) -> None:
+        """remove_stale should delete only expired entries."""
+        cache = BioPortalCache(db_path=tmp_path / "stale.db", ttl_seconds=1)
+        cache.set("search", {"data": "old"}, q="old_query")
+
+        time.sleep(1.1)
+
+        # Add a fresh entry
+        cache.set("search", {"data": "new"}, q="new_query")
+
+        result = cache.remove_stale()
+        assert result["removed_count"] == 1
+        assert result["remaining_count"] == 1
+
+        # Fresh entry should still be there
+        assert cache.get("search", q="new_query") is not None
+
+    def test_clear_all(self, tmp_cache: BioPortalCache) -> None:
+        """clear_all should remove all entries and return the count."""
+        tmp_cache.set("search", {"data": "1"}, q="a")
+        tmp_cache.set("search", {"data": "2"}, q="b")
+        tmp_cache.set("search", {"data": "3"}, q="c")
+
+        result = tmp_cache.clear_all()
+        assert result["cleared_count"] == 3
+
+        assert tmp_cache.get("search", q="a") is None
+        assert tmp_cache.get("search", q="b") is None
+
+    def test_cache_survives_reconnection(self, tmp_path: Path) -> None:
+        """A new BioPortalCache instance should read existing data."""
+        db_path = tmp_path / "persist.db"
+        cache1 = BioPortalCache(db_path=db_path, ttl_seconds=3600)
+        cache1.set("search", {"data": "persistent"}, q="aspirin")
+
+        # Create a new instance with the same db_path
+        cache2 = BioPortalCache(db_path=db_path, ttl_seconds=3600)
+        cached = cache2.get("search", q="aspirin")
+        assert cached is not None
+        assert cached["data"] == "persistent"
+
+    def test_cache_age_increases(self, tmp_cache: BioPortalCache) -> None:
+        """_cache_age_seconds should reflect real elapsed time."""
+        tmp_cache.set("search", {"data": "timed"}, q="aspirin")
+        time.sleep(0.5)
+        cached = tmp_cache.get("search", q="aspirin")
+        assert cached is not None
+        assert cached["_cache_age_seconds"] >= 0.4

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -47,7 +47,9 @@ class TestMakeCacheKey:
 class TestGetCacheDir:
     """Tests for _get_cache_dir."""
 
-    def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def test_env_var_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         """CEDAR_MCP_CACHE_DIR should override the default location."""
         custom_dir = tmp_path / "custom_cache"
         monkeypatch.setenv("CEDAR_MCP_CACHE_DIR", str(custom_dir))


### PR DESCRIPTION
Reduce latency and API load by caching BioPortal term search responses with a configurable TTL (default 24h). Cache persists across server restarts using SQLite.

- Add BioPortalCache class with get/set/remove_stale/clear_all
- Wrap term_search_from_branch and term_search_from_ontology with cache
- Register remove_stale_cache_entries and clear_bioportal_cache MCP tools
- Document cache env vars and Claude Desktop configuration in README