### PR TITLE
Implement SSE and Streamable HTTP transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ uvx cedar-mcp
 cedar-mcp
 ```
 
+### Transport Options
+
+By default, the server uses `stdio` transport. You can also run it as an HTTP server using SSE or streamable-http transports:
+
+```bash
+# SSE transport on default host/port (127.0.0.1:8000)
+cedar-mcp --transport sse \
+  --cedar-api-key "your-cedar-key" \
+  --bioportal-api-key "your-bioportal-key"
+
+# Streamable HTTP on custom host/port
+cedar-mcp --transport streamable-http --host 0.0.0.0 --port 9000 \
+  --cedar-api-key "your-cedar-key" \
+  --bioportal-api-key "your-bioportal-key"
+```
+
+| Flag | Choices | Default | Description |
+|------|---------|---------|-------------|
+| `--transport` | `stdio`, `sse`, `streamable-http` | `stdio` | Transport protocol |
+| `--host` | — | `127.0.0.1` | Host to bind to (HTTP transports only) |
+| `--port` | — | `8000` | Port to bind to (HTTP transports only) |
+
 ## Using with Claude Code
 
 Add the CEDAR MCP server to Claude Code:

--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ Before using this MCP server, you'll need API keys from:
 
 ## Running the CEDAR MCP Server
 
+Set your API keys as environment variables:
+
+```bash
+export CEDAR_API_KEY="your-cedar-key"
+export BIOPORTAL_API_KEY="your-bioportal-key"
+```
+
 ### Option 1: Using UVX (Recommended)
 
 Run directly without installation using `uvx`:
 
 ```bash
-uvx cedar-mcp \
-  --cedar-api-key "your-cedar-key" \
-  --bioportal-api-key "your-bioportal-key"
+uvx cedar-mcp
 ```
 
 ### Option 2: Using pip
@@ -36,27 +41,10 @@ Install from PyPI and run:
 
 ```bash
 pip install cedar-mcp
-
-cedar-mcp \
-  --cedar-api-key "your-cedar-key" \
-  --bioportal-api-key "your-bioportal-key"
-```
-
-### Option 3: Using Environment Variables
-
-Set environment variables instead of command-line arguments:
-
-```bash
-# Set environment variables
-export CEDAR_API_KEY="your-cedar-key"
-export BIOPORTAL_API_KEY="your-bioportal-key"
-
-# Run with uvx
-uvx cedar-mcp
-
-# Or if installed via pip
 cedar-mcp
 ```
+
+> **Note:** The `--cedar-api-key` and `--bioportal-api-key` CLI flags are deprecated and will be removed in a future release. Use environment variables instead.
 
 ### Transport Options
 
@@ -64,14 +52,10 @@ By default, the server uses `stdio` transport. You can also run it as an HTTP se
 
 ```bash
 # SSE transport on default host/port (127.0.0.1:8000)
-cedar-mcp --transport sse \
-  --cedar-api-key "your-cedar-key" \
-  --bioportal-api-key "your-bioportal-key"
+cedar-mcp --transport sse
 
 # Streamable HTTP on custom host/port
-cedar-mcp --transport streamable-http --host 0.0.0.0 --port 9000 \
-  --cedar-api-key "your-cedar-key" \
-  --bioportal-api-key "your-bioportal-key"
+cedar-mcp --transport streamable-http --host 0.0.0.0 --port 9000
 ```
 
 | Flag | Choices | Default | Description |
@@ -85,9 +69,7 @@ cedar-mcp --transport streamable-http --host 0.0.0.0 --port 9000 \
 Add the CEDAR MCP server to Claude Code:
 
 ```bash
-claude mcp add cedar-mcp --uvx \
-  --cedar-api-key "your-cedar-key" \
-  --bioportal-api-key "your-bioportal-key"
+claude mcp add cedar-mcp --uvx -e CEDAR_API_KEY=your-cedar-key -e BIOPORTAL_API_KEY=your-bioportal-key
 ```
 
 ## Using with Claude Desktop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cedar-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "A CEDAR MCP server"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/cedar_mcp/server.py
+++ b/src/cedar_mcp/server.py
@@ -425,7 +425,9 @@ def main():
     if args.transport == "stdio":
         print("Starting CEDAR MCP server (stdio)...")
     else:
-        print(f"Starting CEDAR MCP server ({args.transport}) at http://{args.host}:{args.port} ...")
+        print(
+            f"Starting CEDAR MCP server ({args.transport}) at http://{args.host}:{args.port} ..."
+        )
     mcp.run(transport=args.transport, host=args.host, port=args.port)
 
 

--- a/src/cedar_mcp/server.py
+++ b/src/cedar_mcp/server.py
@@ -41,6 +41,24 @@ def main():
         type=str,
         help="BioPortal API key to use instead of environment variable",
     )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http"],
+        default="stdio",
+        help="Transport protocol (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host to bind to for HTTP transports (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind to for HTTP transports (default: 8000)",
+    )
     args = parser.parse_args()
 
     # Use command-line argument if provided, otherwise use environment variable
@@ -385,8 +403,11 @@ def main():
         return cache.clear_all()
 
     # Start the MCP server
-    print("Starting CEDAR MCP server...")
-    mcp.run()
+    if args.transport == "stdio":
+        print("Starting CEDAR MCP server (stdio)...")
+    else:
+        print(f"Starting CEDAR MCP server ({args.transport}) at http://{args.host}:{args.port} ...")
+    mcp.run(transport=args.transport, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/src/cedar_mcp/server.py
+++ b/src/cedar_mcp/server.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import warnings
 from typing import Any, Dict
 
 from dotenv import load_dotenv
@@ -34,12 +35,12 @@ def main():
     parser.add_argument(
         "--cedar-api-key",
         type=str,
-        help="CEDAR API key to use instead of environment variable",
+        help="(Deprecated) CEDAR API key. Use CEDAR_API_KEY environment variable instead.",
     )
     parser.add_argument(
         "--bioportal-api-key",
         type=str,
-        help="BioPortal API key to use instead of environment variable",
+        help="(Deprecated) BioPortal API key. Use BIOPORTAL_API_KEY environment variable instead.",
     )
     parser.add_argument(
         "--transport",
@@ -61,18 +62,36 @@ def main():
     )
     args = parser.parse_args()
 
+    # Emit deprecation warnings for CLI key flags
+    if args.cedar_api_key:
+        warnings.warn(
+            "--cedar-api-key is deprecated and will be removed in a future release. "
+            "Use the CEDAR_API_KEY environment variable instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+    if args.bioportal_api_key:
+        warnings.warn(
+            "--bioportal-api-key is deprecated and will be removed in a future release. "
+            "Use the BIOPORTAL_API_KEY environment variable instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
     # Use command-line argument if provided, otherwise use environment variable
     CEDAR_API_KEY = args.cedar_api_key or os.getenv("CEDAR_API_KEY")
     if not CEDAR_API_KEY:
         print(
-            "Error: CEDAR API key not provided. Please set CEDAR_API_KEY environment variable or use --cedar-api-key."
+            "Error: CEDAR API key not provided. "
+            "Please set the CEDAR_API_KEY environment variable."
         )
         sys.exit(1)
 
     BIOPORTAL_API_KEY = args.bioportal_api_key or os.getenv("BIOPORTAL_API_KEY")
     if not BIOPORTAL_API_KEY:
         print(
-            "Error: BioPortal API key not provided. Please set BIOPORTAL_API_KEY environment variable or use --bioportal-api-key."
+            "Error: BioPortal API key not provided. "
+            "Please set the BIOPORTAL_API_KEY environment variable."
         )
         sys.exit(1)
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -304,9 +304,12 @@ class TestServerConfiguration:
         # Test SSE transport with custom host/port
         args = parser.parse_args(
             [
-                "--transport", "sse",
-                "--host", "0.0.0.0",
-                "--port", "9000",
+                "--transport",
+                "sse",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9000",
             ]
         )
         assert args.transport == "sse"

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import pytest
+import warnings
 from typing import Dict
 from unittest.mock import patch
 import requests
@@ -219,6 +220,71 @@ class TestServerConfiguration:
         assert args.transport == "stdio"
         assert args.host == "127.0.0.1"
         assert args.port == 8000
+
+    def test_deprecated_cedar_api_key_flag_emits_warning(self):
+        """Test that using --cedar-api-key emits a deprecation warning."""
+        with patch.dict("os.environ", {"CEDAR_API_KEY": "", "BIOPORTAL_API_KEY": ""}):
+            with patch.object(
+                sys, "argv", ["server.py", "--cedar-api-key", "test-key"]
+            ):
+                import argparse
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--cedar-api-key", type=str)
+                parser.add_argument("--bioportal-api-key", type=str)
+                args = parser.parse_args(["--cedar-api-key", "test-key"])
+
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    if args.cedar_api_key:
+                        warnings.warn(
+                            "--cedar-api-key is deprecated and will be removed in a future release. "
+                            "Use the CEDAR_API_KEY environment variable instead.",
+                            DeprecationWarning,
+                            stacklevel=1,
+                        )
+                    assert len(w) == 1
+                    assert issubclass(w[0].category, DeprecationWarning)
+                    assert "--cedar-api-key is deprecated" in str(w[0].message)
+
+    def test_deprecated_bioportal_api_key_flag_emits_warning(self):
+        """Test that using --bioportal-api-key emits a deprecation warning."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--cedar-api-key", type=str)
+        parser.add_argument("--bioportal-api-key", type=str)
+        args = parser.parse_args(["--bioportal-api-key", "test-key"])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            if args.bioportal_api_key:
+                warnings.warn(
+                    "--bioportal-api-key is deprecated and will be removed in a future release. "
+                    "Use the BIOPORTAL_API_KEY environment variable instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "--bioportal-api-key is deprecated" in str(w[0].message)
+
+    def test_no_deprecation_warning_without_api_key_flags(self):
+        """Test that no deprecation warning is emitted when API key flags are not used."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--cedar-api-key", type=str)
+        parser.add_argument("--bioportal-api-key", type=str)
+        args = parser.parse_args([])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            if args.cedar_api_key:
+                warnings.warn("--cedar-api-key is deprecated", DeprecationWarning)
+            if args.bioportal_api_key:
+                warnings.warn("--bioportal-api-key is deprecated", DeprecationWarning)
+            assert len(w) == 0
 
     def test_transport_argument_parsing(self):
         """Test transport-related argument parsing."""

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -196,6 +196,13 @@ class TestServerConfiguration:
         parser = argparse.ArgumentParser(description="CEDAR MCP Python Server")
         parser.add_argument("--cedar-api-key", type=str, help="CEDAR API key")
         parser.add_argument("--bioportal-api-key", type=str, help="BioPortal API key")
+        parser.add_argument(
+            "--transport",
+            choices=["stdio", "sse", "streamable-http"],
+            default="stdio",
+        )
+        parser.add_argument("--host", type=str, default="127.0.0.1")
+        parser.add_argument("--port", type=int, default=8000)
 
         # Test parsing with both arguments
         args = parser.parse_args(
@@ -209,6 +216,56 @@ class TestServerConfiguration:
 
         assert args.cedar_api_key == "test-cedar-key"
         assert args.bioportal_api_key == "test-bioportal-key"
+        assert args.transport == "stdio"
+        assert args.host == "127.0.0.1"
+        assert args.port == 8000
+
+    def test_transport_argument_parsing(self):
+        """Test transport-related argument parsing."""
+        import argparse
+
+        parser = argparse.ArgumentParser(description="CEDAR MCP Python Server")
+        parser.add_argument("--cedar-api-key", type=str)
+        parser.add_argument("--bioportal-api-key", type=str)
+        parser.add_argument(
+            "--transport",
+            choices=["stdio", "sse", "streamable-http"],
+            default="stdio",
+        )
+        parser.add_argument("--host", type=str, default="127.0.0.1")
+        parser.add_argument("--port", type=int, default=8000)
+
+        # Test SSE transport with custom host/port
+        args = parser.parse_args(
+            [
+                "--transport", "sse",
+                "--host", "0.0.0.0",
+                "--port", "9000",
+            ]
+        )
+        assert args.transport == "sse"
+        assert args.host == "0.0.0.0"
+        assert args.port == 9000
+
+        # Test streamable-http transport
+        args = parser.parse_args(["--transport", "streamable-http"])
+        assert args.transport == "streamable-http"
+        assert args.host == "127.0.0.1"
+        assert args.port == 8000
+
+    def test_invalid_transport_argument(self):
+        """Test that invalid transport choice is rejected."""
+        import argparse
+
+        parser = argparse.ArgumentParser(description="CEDAR MCP Python Server")
+        parser.add_argument(
+            "--transport",
+            choices=["stdio", "sse", "streamable-http"],
+            default="stdio",
+        )
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--transport", "invalid"])
 
     def test_api_key_validation_logic(self):
         """Test API key validation logic."""

--- a/uv.lock
+++ b/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cedar-mcp"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Change logs:
* Implement SEE and Streamable HTTP transports via `--transport sse` and `--transport streamable-http`
* Deprecate `--cedar-api-key` and `--bioportal-api-key`. Use the environment variables for better security